### PR TITLE
Stable-TC defaults: spline_order=3, dt-scaled wind-sea floor on by default

### DIFF
--- a/src/Models/WaveGrowthModels2D.jl
+++ b/src/Models/WaveGrowthModels2D.jl
@@ -217,7 +217,11 @@ function WaveGrowth2D(; grid::GG,
     periodic_boundary=true,
     boundary_type="same", # or "minimal", "same", default is same, only used if periodic_boundary is false
     CBsets=nothing,
-    spline_order::Int=1,  # B-spline deposition order: 1=CIC (default), 2=TSC, 3=cubic
+    spline_order::Int=3,  # B-spline particle→grid deposition order: 1=CIC, 2=TSC, 3=cubic (default).
+                          # Order 1/2 imprint a 4-fold grid-axis "cross" on a symmetric TC eye
+                          # (issue #59); cubic (3) restores axisymmetry. Auto-falls back to 1 on
+                          # tripolar grids (higher-order seam remap unsupported). Verify a pure-
+                          # propagation ring stays circular if you change this.
     windsea_merge::Bool=false,  # false = additive deposition (default); true = wind-sea-favoured merge! (Hanson&Phillips 2001)
     movie=false) where {PP<:Union{ParticleDefaults2D,String},GG<:AbstractGrid}
 
@@ -229,9 +233,10 @@ function WaveGrowth2D(; grid::GG,
         error("spline_order must be 1, 2, or 3 (got $spline_order)")
     end
     # Higher-order deposition is not yet supported on tripolar grids (multi-point seam remap is a
-    # separate task); guard rather than silently deposit at the wrong order.
+    # separate task); fall back to CIC there rather than error, so the default (3) works anywhere.
     if spline_order > 1 && typeof(grid) <: MeshGrids && occursin("Tripolar", string(nameof(typeof(grid.stats.Ny))))
-        error("spline_order > 1 is not yet supported on tripolar grids; use spline_order=1.")
+        @warn "spline_order > 1 is not yet supported on tripolar grids; falling back to spline_order = 1."
+        spline_order = 1
     end
 
     # initialize state {SharedArray} given grid and layers

--- a/src/Operators/mapping_2D.jl
+++ b/src/Operators/mapping_2D.jl
@@ -336,8 +336,14 @@ function remesh!(PI::ParticleInstance2D, S::StateTypeL1,
         # tiny, ill-defined net momentum that drives the #64 remesh limit cycle at wind/calm
         # interfaces, while scaling with the wind so it never over-deactivates an energetic
         # wind sea. α is tunable (PM is fully developed → an upper bound, so α is small).
-        m_amp_min = ODEs.windsea_alpha > 0 ?
-                max(ODEs.m_amp_minimum, ODEs.windsea_alpha * FetchRelations.windsea_momentum_PM(sqrt(wind_speed_squared))) :
+        # dt-scaled wind-sea floor: the momentum eroded per unit time ∝ α/dt, so a constant
+        # α drains the field at small dt (collapse). Scaling α ∝ min(1, dt/dt_ref) with
+        # dt_ref = 10 min (the validated sweet spot) bounds the erosion and prevents the
+        # small-dt collapse, making `windsea_alpha` safe to leave on by default. See the
+        # eyewall-stability FINDINGS (analysis/stability) for the α/dt collapse calibration.
+        α_eff = ODEs.windsea_alpha * min(1.0, ODEs.timestep / 600.0)
+        m_amp_min = α_eff > 0 ?
+                max(ODEs.m_amp_minimum, α_eff * FetchRelations.windsea_momentum_PM(sqrt(wind_speed_squared))) :
                 ODEs.m_amp_minimum
         m_amp    = speed(u_state[2], u_state[3])
 

--- a/src/ParticleSystems/particle_waves_v6.jl
+++ b/src/ParticleSystems/particle_waves_v6.jl
@@ -126,8 +126,21 @@ $(DocStringExtensions.FIELDS)
     wind_min_squared::Float64 = 4.0
     "minimum momentum amplitude for vertex reconstruction (crash floor); below this threshold the direction is ill-defined"
     m_amp_minimum::Float64 = 1e-6
-    "wind-sea scaling of the reconstruction floor: local threshold = max(m_amp_minimum, windsea_alpha · |m|_ws,PM(U_local)). 0 disables the local scaling (constant m_amp_minimum)."
-    windsea_alpha::Float64 = 0.0
+    """
+    Wind-sea-scaled reconstruction floor: local threshold =
+    max(m_amp_minimum, α_eff · |m|_ws,PM(U_local)), with α_eff = windsea_alpha · min(1, dt/10min)
+    automatically dt-scaled (bounds erosion at small dt; see `mapping_2D`). |m|_ws,PM is the
+    fully-developed Pierson–Moskowitz wind-sea momentum (∝ U³), so the floor scales with the
+    local wind and never over-deactivates an energetic sea; in calm regions it falls back to
+    `m_amp_minimum` (swell is never discarded).
+
+    This damps the remesh limit cycle at wind/calm interfaces and the rotating TC eyewall
+    (energy-conserving for a resolved eyewall). DEFAULT ≈0.005 — the validated stable-TC value
+    (use with spline_order=3 and a resolved eyewall, dx ≲ Rmax/20, wave Courant C_cg = c_g·dt/dx
+    ≈ 2–5). Set 0 to disable. CAUTION: on an UNDER-resolved eyewall the floor can collapse the
+    storm — resolve the eyewall first. See analysis/stability FINDINGS_eyewall_stability_courant.
+    """
+    windsea_alpha::Float64 = 0.005
     "solver method for ODE system"
     #alternatives
     #Rosenbrock23(), AutoVern7(Rodas4()) ,AutoTsit5(Rosenbrock23()) , Tsit5()


### PR DESCRIPTION
## Summary

Make the **validated stable tropical-cyclone configuration the default**, so a stationary symmetric TC eye is both **steady in time and axisymmetric in space** out of the box. Derived from a 900+ run eyewall/discontinuity stability sweep (`analysis/stability` in the parent repo).

## Changes

1. **`WaveGrowth2D`: `spline_order` default `1 → 3`** (cubic deposition). Order 1 (CIC) / 2 (TSC) imprint a 4-fold grid-axis "cross" on a symmetric eye ([#59](https://github.com/mochell/PiCLES.jl/issues/59)); cubic restores axisymmetry. Tripolar grids **auto-fall-back to order 1 with a warning** (previously a hard error), so the new default is safe on any grid.

2. **`ODESettings.windsea_alpha` default `0.0 → 0.005`** — the wind-sea-scaled reconstruction floor that damps the remesh limit cycle at wind/calm interfaces and the rotating eyewall (energy-conserving for a resolved eyewall).

3. **`mapping_2D`: the floor is now automatically dt-scaled**, `α_eff = windsea_alpha · min(1, dt/10min)`. Erosion per unit time ∝ `α/dt`, so a constant `α` drains the field at small `dt`; the dt-scaling bounds erosion and **prevents the small-dt collapse**, making the floor safe to leave on by default.

## Recommended regime (now in docstrings)

- Resolve the eyewall: **`dx ≲ Rmax/20`** (≥40 ideal).
- Pick `dt` so the **wave Courant `C_cg = c_g·dt/dx ≈ 2–5`** (advective `C_U = U·dt/dx ≈ 10–20`) — the eyewall stability **sweet spot** (both temporal pulsing and spatial asymmetry minimize at `C_cg ≈ 3`). Typical `dt ≈ 5–10 min`.
- **Caution:** on an *under-resolved* eyewall the floor can still collapse the storm — resolve first.

## Validation

With these defaults (order 3, `windsea_alpha=0.005` dt-scaled, `dx ≲ Rmax/20`, `C_cg ≈ 3`), a CAT3–5 storm eyewall reaches `cv ~ 1e-3` (temporal) and `asym ~ 1e-3` (axisymmetry); wind/calm discontinuities are fully steady. Full write-up: `analysis/stability/FINDINGS_eyewall_stability_courant.{md,pdf}`.

## ⚠️ Compatibility

This **changes default numerics**. Existing test/regression baselines will shift and need re-blessing. Downstream code that omits `spline_order`/`windsea_alpha` will get the new behavior; pass explicit values to keep the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)